### PR TITLE
Updates fields form with longitude and latitude

### DIFF
--- a/src/common/fields.js
+++ b/src/common/fields.js
@@ -16,6 +16,14 @@ export const HOME_FIELDS = [
         name: 'address',
     },
     {
+        labelName: 'Longitude',
+        name: 'lontitude',
+    },
+    {
+        labelName: 'Latitude',
+        name: 'latitude',
+    },
+    {
         labelName: 'Price',
         name: 'price',
     },


### PR DESCRIPTION
> In the create home page add fields latitude and longitude

Placed additional fields below address as that felt the most logical section!

Original form field:

<img width="435" alt="original" src="https://user-images.githubusercontent.com/77736272/211145681-ce82accc-1bdc-4581-848a-8c5ccd4f9535.PNG">

Revised form field:

<img width="451" alt="revised" src="https://user-images.githubusercontent.com/77736272/211145686-ac9f9f8b-cd9b-4deb-9241-5e207bdca237.PNG">
