### PR TITLE
changed '/link-meetings' to 'list-meetings' in the header

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -131,7 +131,7 @@ export default function Header() {
                 </p>
                 {user._id && (
                     <p>
-                        <Link style={{ textDecoration: 'none' }} to={'/link-meetings'}>
+                        <Link style={{ textDecoration: 'none' }} to={'/list-meetings'}>
                             <MdMeetingRoom size={25} />
                         </Link>
                     </p>


### PR DESCRIPTION
In the upper right corner, there are 2 links - one for chat and one for meetings. The one for meetings is to /link-meetings and it is wrong, it has to be to /list-meetings. So I changed it to /list-meetings