### PR TITLE
Added a message for users to log in before they can sell

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,11 +5,26 @@ import { hostUrl } from '../../common/urls';
 import { UserContext } from '../../context/UserContext';
 import { BiMessageDetail } from 'react-icons/bi';
 import { MdMeetingRoom } from 'react-icons/md';
+import { toast } from 'react-toastify';
 
 export default function Header() {
     const [click, setClick] = useState(false);
     const [sellClick, setSellClick] = useState(false);
     const { user, setUser } = useContext(UserContext);
+
+    const SellHandler = () => {
+        if (!user._id) {
+            toast.error('You have to be signed in as a seller!', {
+                autoClose: 3000,
+                pauseOnHover: false,
+            });
+        } else if (user.role !== 'seller') {
+            toast.error('upgrade to a seller role to sell!', {
+                autoClose: 3000,
+                pauseOnHover: false,
+            });
+        }
+    };
 
     const onLogOutHandler = () => {
         if (!user) return;
@@ -75,19 +90,25 @@ export default function Header() {
                                 <div className="buy-element">
                                     <Link
                                         className="buy-patch"
-                                        to="/create-home"
+                                        to={
+                                            user._id && user.role == 'seller' ? '/create-home' : '/'
+                                        }
                                         onMouseLeave={() => {
                                             setSellClick(false);
                                         }}
+                                        onClick={SellHandler}
                                     >
                                         Home
                                     </Link>
                                     <Link
                                         className="buy-patch"
-                                        to="/create-land"
+                                        to={
+                                            user._id && user.role == 'seller' ? '/create-land' : '/'
+                                        }
                                         onMouseLeave={() => {
                                             setSellClick(false);
                                         }}
+                                        onClick={SellHandler}
                                     >
                                         Land
                                     </Link>


### PR DESCRIPTION
When a user goes to Sell and clicks on Land or Home, he is redirected to creating pages. If the user is not signed in or the user does not have a seller role, I showed a message:

You have to be signed in as a seller. If you are signed in already, upgrade to the seller role.